### PR TITLE
Update bookmarklet

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Bookmarklet that shows the numbers of [Trello](http://trello.com/) cards.
 Add the bookmarklet by selecting and dragging it to your bookmarks bar. Then go to your Trello Board and click the bookmark to toggle the numbers.
 
 ```javascript
-javascript:!function(){var o=$(".card-short-id");o.each(function(){$(this).text($(this).text().replace("#","").replace("#","").replace("N.%C2%BA ", ""))});o.hasClass("hide")?o.removeClass("hide").css({"font-weight":"normal","font-size":".8em","margin-right":"5px",padding:"2.3px 6px",background:$("body").css("background-color"),"border-radius":"10px",color:"#f6f6f6"}):o.addClass("hide")}();
+javascript:void(function(){var o=$(".card-short-id");o.each(function(){$(this).text($(this).text().replace("#","").replace("#","").replace("N.%C2%BA ", ""))});o.hasClass("hide")?o.removeClass("hide").css({"font-weight":"normal","font-size":".8em","margin-right":"5px",padding:"2.3px 6px",background:$("body").css("background-color"),"border-radius":"10px",color:"#f6f6f6"}):o.addClass("hide")}());
 ```


### PR DESCRIPTION
Old version was redirecting me to a page containing 'true'. This version appears to work in Firefox 54.0.1 and Chrome 58.0.3029.110.